### PR TITLE
Added findArtifactFromTask + tests

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -72,6 +72,10 @@ var launch = function(profile) {
     // Create API router and publish reference if needed
     return v1.setup({
       context: {
+        queue:          new taskcluster.Queue({
+          credentials:  cfg.get('taskcluster:credentials'),
+          baseUrl:      cfg.get('taskcluster:queueBaseUrl')
+        }),
         validator:      validator,
         IndexedTask:    IndexedTask,
         Namespace:      Namespace

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "lodash":                           "2.4.1",
     "debug":                            "2.1.1",
     "taskcluster-client":               "0.22.0",
-    "taskcluster-base":                 "0.7.22"
+    "taskcluster-base":                 "0.7.22",
+    "superagent":                       "^1.2.0",
+    "superagent-promise":               "^0.2.0"
   },
   "devDependencies": {
     "mocha":                            "2.1.0",

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -6,6 +6,12 @@ suite("API", function() {
   var slugid      = require('slugid');
   var _           = require('lodash');
   var subject     = helper.setup({title: "api test"});
+  var taskcluster = require('taskcluster-client');
+  var request     = require('superagent-promise');
+
+  // Artifact names that we have assigned scopes to testing credentials for.
+  var publicArtifactName = 'public/dummy-test-provisioner.log';
+  var privateArtifactName = 'private/dummy-test-provisioner.log';
 
   // Create expiration
   var expiry = new Date();
@@ -60,6 +66,109 @@ suite("API", function() {
       result.tasks.forEach(function(task) {
         assert(task.namespace.indexOf('.') === -1, "shouldn't have any dots");
       });
+    });
+  });
+
+  test('access public and private artifact', function() {
+    var taskId = slugid.v4();
+    return subject.queue.createTask(taskId, {
+      provisionerId:    "dummy-test-provisioner",
+      workerType:       "dummy-test-worker-type",
+      retries:          3,
+      created:          taskcluster.fromNowJSON(),
+      deadline:         taskcluster.fromNowJSON('30 min'),
+      payload: {
+        desiredResolution:  "success"
+      },
+      metadata: {
+        name:           "Print `'Hello World'` Once",
+        description:    "This task will prìnt `'Hello World'` **once**!",
+        owner:          "jojensen@mozilla.com",
+        source:         "https://github.com/taskcluster/taskcluster-index"
+      },
+      tags: {
+        objective:      "Test task indexing"
+      }
+    }).then(function() {
+      debug("### Claim task");
+      return subject.queue.claimTask(taskId, 0, {
+        workerGroup:  'dummy-test-workergroup',
+        workerId:     'dummy-test-worker-id'
+      });
+    }).then(function() {
+      debug("### Create public artifact");
+      return subject.queue.createArtifact(taskId, 0, publicArtifactName, {
+        storageType:  'error',
+        expires:      taskcluster.fromNowJSON('24 hours'),
+        reason:       'invalid-resource-on-worker',
+        message:      "Testing that we can access public artifacts from index"
+      });
+    }).then(function() {
+      debug("### Create private artifact");
+      return subject.queue.createArtifact(taskId, 0, privateArtifactName, {
+        storageType:  'error',
+        expires:      taskcluster.fromNowJSON('24 hours'),
+        reason:       'file-missing-on-worker',
+        message:      "Testing that we can access private artifacts from index"
+      });
+    }).then(function() {
+      debug("### Report task completed");
+      return subject.queue.reportCompleted(taskId, 0);
+    }).then(function() {
+      debug("### Insert task into index");
+      return subject.index.insertTask(taskId + '.my-task', {
+        taskId:     taskId,
+        rank:       41,
+        data:       {hello: "world"},
+        expires:    taskcluster.fromNowJSON('24 hours')
+      });
+    }).then(function() {
+      debug("### Download public artifact using index");
+      var url = subject.index.buildUrl(
+        subject.index.findArtifactFromTask,
+        taskId + '.my-task',
+        publicArtifactName
+      );
+      return request.get(url).redirects(0).end().catch(function(err) {
+        return err.response;
+      });
+    }).then(function(res) {
+      assert(res.statusCode === 303, "Expected 303 redirect");
+      return request.get(res.headers.location).end().then(function() {
+        assert(false, "Expected 403 response");
+      }, function(err) {
+        assert(err.response.statusCode === 403, "Expected 403");
+        assert(err.response.body.reason === 'invalid-resource-on-worker');
+      });
+    }).then(function() {
+      debug("### Download private artifact using index (no auth)");
+      var url = subject.index.buildUrl(
+        subject.index.findArtifactFromTask,
+        taskId + '.my-task',
+        privateArtifactName
+      );
+      return request.get(url).redirects(0).end().catch(function(err) {
+        return err.response;
+      });
+    }).then(function(res) {
+      assert(res.statusCode === 401, "Expected 401 access denied");
+    }).then(function() {
+      debug("### Download private artifact using index (with auth)");
+      var url = subject.index.buildSignedUrl(
+        subject.index.findArtifactFromTask,
+        taskId + '.my-task',
+        privateArtifactName, {
+        expiration:     15 * 60
+      });
+      return request.get(url).redirects(0).end().catch(function(err) {
+        return err.response;
+      });
+    }).then(function(res) {
+      assert(res.statusCode === 303, "Expected 303 redirect");
+      // We can't call the URL because server isn't configured with real
+      // credentials in the test.
+      assert(res.headers.location.indexOf('bewit') !== -1,
+             "Expected redirect to signed url");
     });
   });
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -40,31 +40,6 @@ var defaultClients = [
   }
 ];
 
-/** Return a promise that sleeps for `delay` ms before resolving */
-exports.sleep = function(delay) {
-  return new Promise(function(accept) {
-    setTimeout(accept, delay);
-  });
-}
-
-/** Poll a function that returns a promise, until it resolves */
-exports.poll = function(doPoll, attempts, interval) {
-  attempts = attempts || 90;
-  interval = interval || 1000;
-  var pollAgain = function() {
-    return doPoll().catch(function(err) {
-      if (attempts > 0) {
-        attempts -= 1;
-        return exports.sleep(interval).then(function() {
-          return pollAgain();
-        });
-      }
-      throw err;
-    });
-  };
-  return pollAgain();
-};
-
 /** Setup testing */
 exports.setup = function(options) {
   // Provide default configuration

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -6,6 +6,7 @@ suite('Indexing', function() {
   var slugid      = require('slugid');
   var _           = require('lodash');
   var subject     = helper.setup({title: "indexing test"});
+  var base        = require('taskcluster-base');
 
   // Create datetime for created and deadline as 25 minutes later
   var created = new Date();
@@ -67,13 +68,13 @@ suite('Indexing', function() {
         workerId:     'dummy-test-worker-id'
       });
     }).then(function() {
-      return helper.sleep(100);
+      return base.testing.sleep(100);
     }).then(function() {
       debug("### Report task completed");
       return subject.queue.reportCompleted(taskId, 0);
     }).then(function() {
       debug("### Find task in index");
-      return helper.poll(function() {
+      return base.testing.poll(function() {
         return subject.index.findTask(myns + '.my-indexed-thing');
       });
     }).then(function(result) {
@@ -145,13 +146,13 @@ suite('Indexing', function() {
         workerId:     'dummy-test-worker-id'
       });
     }).then(function() {
-      return helper.sleep(100);
+      return base.testing.sleep(100);
     }).then(function() {
       debug("### Report task completed");
       return subject.queue.reportCompleted(taskId, 0);
     }).then(function() {
       debug("### Find task in index");
-      return helper.poll(function() {
+      return base.testing.poll(function() {
         return subject.index.findTask(myns + '.my-indexed-thing');
       });
     }).then(function(result) {


### PR DESCRIPTION
API end-point that will redirect a request for an artifact to the queue. This is mostly useful for shell scripts and other quick hacks.

People using the client should make the two API calls instead... Well, that would be my recommendation.