### PR TITLE
edit and expand the API docs

### DIFF
--- a/schemas/list-tasks-response.yml
+++ b/schemas/list-tasks-response.yml
@@ -18,16 +18,13 @@ properties:
         namespace:
           title:          "Namespace"
           description: |
-            Namespace of the indexed task, used to find the indexed task in the
-            index.
+            Index path of the task.
           type:           string
           maxLength:      255
         taskId:
           title:          "Task Identifier"
           description: |
-            Unique task identifier, this is UUID encoded as
-            [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-            stripped of `=` padding.
+            Unique task identifier for the task currently indexed at `namespace`.
           type:           string
           pattern:        {$const: slugid-pattern}
         rank:


### PR DESCRIPTION
Mostly an edit, but I added language about stability of URLs in a few places.  @jhford does that do something to address your concerns in taskcluster/taskcluster-rfcs#56?

@jonasfj I renamed `namespace` to `index path` when it is a leafe, since otherwise we were using the word "namespace" ambiguously.  The only place I didn't change it is in the schema, where `namespace` is part of the schema.  I can revert that bit if you're not happy with it.