### PR TITLE
Bug 1414572 - Delete expired entries (using Linear Scan)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,10 @@ defaults:
     # Name of pulse queue, if a non-exclusive queue is to be used.
     listenerQueueName:            null
 
+    # Time delay before expiring artifacts, in readable format, see:
+    # taskcluster.fromNow, notice this should be negative!
+    expirationDelay:              '-1 day'
+
   # Server configuration
   server:
     # Public URL from which the server can be accessed (used for persona)

--- a/src/data.js
+++ b/src/data.js
@@ -151,6 +151,14 @@ Namespace.expireEntries = function(indexedTask, continuationToken=null) {
   }).then(async (data) => {
     console.log('..namespaces', data);
     var dataLength = data.entries.length;
+    now = new Date();
+    now = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      0, 0, 0, 0
+    );
+    now = now.getTime();
     
     for (var i=0; i<dataLength; i++) {
       let entry = data.entries[i];
@@ -164,7 +172,7 @@ Namespace.expireEntries = function(indexedTask, continuationToken=null) {
       // always later than the child's. Hence, we can delete an
       // entry without checking its children.
       await indexedTask.expireTasks(namespace);
-      if (entry.expires.getTime() < Date.now()) {
+      if (entry.expires.getTime() < now) {
         console.log(`remove namespace ${namespace}`);
         entry.remove(false, true);
       }

--- a/src/data.js
+++ b/src/data.js
@@ -141,7 +141,7 @@ Namespace.ensureNamespace = function(namespace, expires) {
 };
 
 /**Delete expired entries */
-Namespace.expireEntries = async function(now, indexedTask) {
+Namespace.expireEntries = async function(now) {
   let continuationToken = undefined;
   while (1) {
     let data = await this.scan({

--- a/src/data.js
+++ b/src/data.js
@@ -176,7 +176,7 @@ Namespace.expireEntries = function(now, indexedTask, continuationToken=null) {
   });   
 };
 
-IndexedTask.expireTasks = function(now, continuationToken=null) {
+IndexedTask.expireTasks = function(now, continuationToken=undefined) {
 
   return this.scan({
     expires: Entity.op.lessThan(now),

--- a/src/data.js
+++ b/src/data.js
@@ -78,7 +78,7 @@ Namespace.ensureNamespace = function(namespace, expires) {
   expires = new Date(
     expires.getFullYear(),
     expires.getMonth(),
-    expires.getDate(),
+    expires.getDate() + 1,
     0, 0, 0, 0
   );
 

--- a/src/data.js
+++ b/src/data.js
@@ -149,6 +149,7 @@ Namespace.expireEntries = function(indexedTask, continuationToken=null) {
     limit:         500,
     continuation:   continuationToken,
   }).then(async (data) => {
+    console.log('..namespaces', data);
     var dataLength = data.entries.length;
     
     for (var i=0; i<dataLength; i++) {
@@ -184,6 +185,7 @@ IndexedTask.expireTasks = function(namespace, continuationToken=null) {
     limit:         500,
     continuation:   continuationToken,
   }).then(async (data) => {
+    console.log('..indexed tasks ', data);
     var dataLength = data.entries.length;
 
     for (var i=0; i<dataLength; i++) {

--- a/src/data.js
+++ b/src/data.js
@@ -165,7 +165,7 @@ Namespace.expireEntries = async function(now) {
       // always later than the child's. Hence, we can delete an
       // entry without checking its children.
       console.log(`remove namespace ${namespace}`);
-      entry.remove(false, true);
+      //entry.remove(false, true);
     }
 
     if (!data.continuation) {
@@ -191,7 +191,7 @@ IndexedTask.expireTasks = async function(now) {
     for (var i=0; i<dataLength; i++) {
       task = data.entries[i];
       console.log(`remove task ${task.name}`);
-      task.remove(false, true);
+      //task.remove(false, true);
     }
     if (!data.continuation) {
       break;

--- a/src/data.js
+++ b/src/data.js
@@ -141,7 +141,7 @@ Namespace.ensureNamespace = function(namespace, expires) {
 };
 
 /**Delete expired entries */
-Namespace.expireEntries = function(now, indexedTask, continuationToken=null) {
+Namespace.expireEntries = function(now, indexedTask, continuationToken=undefined) {
   //console.log(`expireEntries in '${parent}' with token '${continuationToken}'`);
   return this.scan({
     expires: Entity.op.lessThan(now),

--- a/src/data.js
+++ b/src/data.js
@@ -141,15 +141,8 @@ Namespace.ensureNamespace = function(namespace, expires) {
 };
 
 /**Delete expired entries */
-Namespace.expireEntries = function(indexedTask, continuationToken=null) {
+Namespace.expireEntries = function(now, indexedTask, continuationToken=null) {
   //console.log(`expireEntries in '${parent}' with token '${continuationToken}'`);
-  now = new Date();
-  now = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-    0, 0, 0, 0
-  );
   return this.scan({
     expires: Entity.op.lessThan(now),
   },
@@ -176,7 +169,7 @@ Namespace.expireEntries = function(indexedTask, continuationToken=null) {
     }
 
     if (data.continuation) {
-      await Namespace.expireEntries(indexedTask, data.continuation);
+      await Namespace.expireEntries(now, indexedTask, data.continuation);
     } else {
       await indexedTask.expireTasks(now);
     }

--- a/src/data.js
+++ b/src/data.js
@@ -172,7 +172,6 @@ Namespace.expireEntries = async function(now, indexedTask) {
       break;
     }
   }
-  await indexedTask.expireTasks(now);
 };
 
 IndexedTask.expireTasks = async function(now) {

--- a/src/main.js
+++ b/src/main.js
@@ -139,8 +139,10 @@ var load = loader({
     setup: async ({cfg, IndexedTask, Namespace}) => {
       let now = taskcluster.fromNow(cfg.app.expirationDelay);
 
-      debug('Expiring index entries and namespaces');
-      await Namespace.expireEntries(now, IndexedTask);
+      debug('Expiring namespaces');
+      await Namespace.expireEntries(now);
+      debug('Expiring indexed tasks');
+      await IndexedTask.expireTasks(now);
 
       monitor.count('expire.done');
       monitor.stopResourceMonitoring();

--- a/src/main.js
+++ b/src/main.js
@@ -137,11 +137,12 @@ var load = loader({
   expire: {
     requires: ['cfg', 'IndexedTask', 'Namespace'],
     setup: async ({cfg, IndexedTask, Namespace}) => {
+      let now = taskcluster.fromNow(cfg.app.expirationDelay);
 
       debug('Expiring index entries and namespaces');
-      await Namespace.expireEntries('', IndexedTask);
+      await Namespace.expireEntries(now, IndexedTask);
 
-      monitor.count('expire-artifacts.done');
+      monitor.count('expire.done');
       monitor.stopResourceMonitoring();
       await monitor.flush();
     },

--- a/src/main.js
+++ b/src/main.js
@@ -135,8 +135,8 @@ var load = loader({
   },
 
   expire: {
-    requires: ['cfg', 'IndexedTask', 'Namespace'],
-    setup: async ({cfg, IndexedTask, Namespace}) => {
+    requires: ['cfg', 'monitor', 'IndexedTask', 'Namespace'],
+    setup: async ({cfg, monitor, IndexedTask, Namespace}) => {
       let now = taskcluster.fromNow(cfg.app.expirationDelay);
 
       debug('Expiring namespaces');

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -136,7 +136,10 @@ suite('Indexing', () => {
   test('Expiring Index', async function() {
     // Create expiration
     var expiry = new Date();
-    expiry.setMinutes(expiry.getMinutes() - 25);
+
+    // Namespace.expireEntries removes tasks that are
+    // more than a day past expiry
+    expiry.setDate(expiry.getDate() - 1);
     
     var myns     = slugid.v4();
     var taskId   = slugid.v4();
@@ -150,7 +153,7 @@ suite('Indexing', () => {
     let result = await helper.index.findTask(myns + '.my-task');
     assert(result.taskId === taskId, 'Wrong taskId');
 
-    expiry.setMinutes(expiry.getMinutes() + 50);
+    expiry.setDate(expiry.getDate() + 1);
     await helper.index.insertTask(myns + '.my-task2', {
       taskId:     taskId2,
       rank:       42,
@@ -160,6 +163,7 @@ suite('Indexing', () => {
     result = await helper.index.findTask(myns + '.my-task2');
     assert(result.taskId === taskId2, 'Wrong taskId');
     
+    // Expires namespace and indexed tasks.
     await helper.handlers.Namespace.expireEntries(helper.handlers.IndexedTask);
     
     try {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -160,7 +160,7 @@ suite('Indexing', () => {
     result = await helper.index.findTask(myns + '.my-task2');
     assert(result.taskId === taskId2, 'Wrong taskId');
     
-    await helper.handlers.Namespace.expireEntries('', helper.handlers.IndexedTask);
+    await helper.handlers.Namespace.expireEntries(helper.handlers.IndexedTask);
     
     try {
       await helper.index.findTask(myns + '.my-task');

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -163,8 +163,11 @@ suite('Indexing', () => {
     result = await helper.index.findTask(myns + '.my-task2');
     assert(result.taskId === taskId2, 'Wrong taskId');
     
+    // Set now to one day in the past 
+    var now = taskcluster.fromNow('- 1 day');
+    debug('Expiring entries at: %s, from before %s', new Date(), now);
     // Expires namespace and indexed tasks.
-    await helper.handlers.Namespace.expireEntries(helper.handlers.IndexedTask);
+    await helper.handlers.Namespace.expireEntries(now, helper.handlers.IndexedTask);
     
     try {
       await helper.index.findTask(myns + '.my-task');

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -190,7 +190,7 @@ suite('Indexing', () => {
     });
     let result = await helper.index.findTask(myns + '.one-ns.my-task');
     assert(result.taskId === taskId, 'Wrong taskId');
-    expiry.setDate(expiry.getDate() - 1);
+    expiry.setDate(expiry.getDate() - 2);
     await helper.index.insertTask(myns + '.another-ns.my-task', {
       taskId:     taskId2,
       rank:       42,

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -133,7 +133,7 @@ suite('Indexing', () => {
     assert.equal(result.taskId, taskId, 'Wrong taskId');
   });
 
-  test('Expiring Index', async function() {
+  test('Expiring Indexed Tasks', async function() {
     // Create expiration
     var expiry = new Date();
 
@@ -167,7 +167,7 @@ suite('Indexing', () => {
     var now = taskcluster.fromNow('- 1 day');
     debug('Expiring entries at: %s, from before %s', new Date(), now);
     // Expires namespace and indexed tasks.
-    await helper.handlers.Namespace.expireEntries(now, helper.handlers.IndexedTask);
+    await helper.handlers.IndexedTask.expireTasks(now);
     
     try {
       await helper.index.findTask(myns + '.my-task');


### PR DESCRIPTION
I changed `Namespace.expireEntries` to perform a full table scan of namespaces and deleting the indexed tasks under each namespace before deleting the namespace itself (only if its expired).  `IndexedTask.expireTasks` function is still unchanged.
 Do we require to use a full table scan there too?
