### PR TITLE
Remove things in parallel when expring

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -140,9 +140,11 @@ var load = loader({
       let now = taskcluster.fromNow(cfg.app.expirationDelay);
 
       debug('Expiring namespaces');
-      await Namespace.expireEntries(now);
+      let namespaces = await Namespace.expireEntries(now);
+      debug(`Expired ${namespaces} namespaces`);
       debug('Expiring indexed tasks');
-      await IndexedTask.expireTasks(now);
+      let tasks = await IndexedTask.expireTasks(now);
+      debug(`Expired ${tasks} tasks`);
 
       monitor.count('expire.done');
       monitor.stopResourceMonitoring();


### PR DESCRIPTION
I suspect that the existing expiration process operates near to the
insertion rate -- meaning that it will never catch up.  Remving 100
entries at a time should help a little bit.

@ydidwania what do you think?