### PR TITLE
fix assertion about iterations

### DIFF
--- a/test/api_test.js
+++ b/test/api_test.js
@@ -121,7 +121,7 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
         }
         opts.continuationToken = result.continuationToken;
       }
-      assert.equal(iterations, 4);
+      assume(iterations).at.least(4);
       assert.equal(results.length, 4);
       testValidNamespaces(results, ['abc', 'bbc', 'cbc', 'dbc']);
     });


### PR DESCRIPTION
The underlying Azure table started returning a continuationToken with
the last result, then an empty set of results in the fifth iteration.
This is perfectly valid!