### PR TITLE
Bug 1456909 - fix call to oneShot

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -168,7 +168,7 @@ var load = loader({
   expire: {
     requires: ['cfg', 'monitor', 'IndexedTask', 'Namespace'],
     setup: ({cfg, monitor, IndexedTask, Namespace}) => {
-      return monitor.oneShot(async () => {
+      return monitor.oneShot('expire', async () => {
         const now = taskcluster.fromNow(cfg.app.expirationDelay);
 
         debug('Expiring namespaces');


### PR DESCRIPTION
Whoops..  I also added https://github.com/taskcluster/taskcluster-lib-monitor/pull/90 to catch this error.