### PR TITLE
Bug 1505405 - upgrade tc-lib-pulse

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "taskcluster-lib-docs": "^10.0.0",
     "taskcluster-lib-loader": "^10.0.0",
     "taskcluster-lib-monitor": "^11.1.1",
-    "taskcluster-lib-pulse": "^2.0.8",
+    "taskcluster-lib-pulse": "^11.1.0",
     "taskcluster-lib-validate": "^11.0.2",
     "typed-env-config": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,10 +2926,10 @@ taskcluster-lib-monitor@^11.1.1:
     statsum "^0.6.0"
     taskcluster-client "^10.0.0"
 
-taskcluster-lib-pulse@^2.0.8:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-pulse/-/taskcluster-lib-pulse-2.1.0.tgz#ba1927cd59f7e83b28530f9d73e92050fae426e3"
-  integrity sha512-NSTC9BoOct+Zjt6O1niqXVOkHi1QulAYSVIJfcz7nI4acbSpMEWz1jwszcmf/dcheX/6oXiywFB8VXF4sCyJGg==
+taskcluster-lib-pulse@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-pulse/-/taskcluster-lib-pulse-11.1.0.tgz#bfcdbacbc70d0911b86f843e1a1b90649662cde0"
+  integrity sha512-L8dfCWWJtK3dAipQElOLsMCPiOFsnxzu0qwrQGJ3Qe4V//rxhRsdKsWYWPqejJ887qHTrQLVLMQi10MHY+WCvA==
   dependencies:
     amqplib "^0.5.2"
     aws-sdk "^2.331.0"


### PR DESCRIPTION
This service only consumes messages, so there's no version -> apiVersion
change to make.